### PR TITLE
feat(operator): backlog dry-run classification tooling

### DIFF
--- a/operator/.gitignore
+++ b/operator/.gitignore
@@ -82,3 +82,7 @@ Thumbs.db
 # Ephemeral fixture temp dirs
 fixtures/_tmp/
 state/_tmp*
+
+# backlog dry-run outputs
+scripts/backlog/out/
+

--- a/operator/scripts/backlog/README.md
+++ b/operator/scripts/backlog/README.md
@@ -14,30 +14,55 @@ python3 build_backlog_dry_run.py \
 
 | Disposition | Meaning |
 |---|---|
-| `canonical_actionable` | Earliest open issue (by `createdAt`, then lowest number) for a normalized source **not** in the live catalog |
-| `normalized_source_duplicate` | Later open issue sharing the same normalized source as a canonical sibling (GitHub untouched; mapping preserved) |
-| `already_published` | Normalized source already present in the live skills catalog |
+| `canonical_actionable` | Earliest open issue (by `createdAt`, then lowest number) for a normalized source identity **not** already published |
+| `normalized_source_duplicate` | Later open issue sharing the same normalized source identity as a canonical sibling |
+| `already_published` | Repository identity **and** explicit subpath (when available) support a match to the live catalog |
 | `missing_source` | No extractable source URL in title/body |
-| `invalid_source` | URLs present but none normalize to a usable repo identity |
+| `invalid_source` | URLs present but none normalize to a usable identity |
+| `ambiguous_manual_review` | Competing identities in one issue, or publish alignment is unclear |
 
-Ambiguous / manual_review is reserved for future rules; current classifier does not emit it.
+## URL / identity rules
 
-## URL normalization (conservative)
+Implemented in `normalize.py` + `build_backlog_dry_run.py`:
 
-Implemented in `normalize.py`:
+### Candidate extraction
 
-- Prefer first GitHub repo URL found in body/title; else first non-empty normalized URL
+- Extract **all** candidate source URLs from body/title (not first-URL-only)
+- Each candidate normalizes to `{repo, subpath, identity_key}`
+- If multiple URLs normalize to the **same** `identity_key` → classify normally
+- If they normalize to **competing** identities → `ambiguous_manual_review`
+
+### Repository vs skill identity (monorepo)
+
+| Precedence | Rule |
+|---|---|
+| 1 | `owner/repo` is the **repository identity** |
+| 2 | Explicit GitHub `tree`/`blob` path after the ref is a **secondary skill identity** (`subpath`) |
+| 3 | Dedupe key = `repo::subpath` (empty subpath = root-repository submission) |
+| 4 | Two different explicit subpaths in one monorepo are **not** duplicates |
+| 5 | Root-repository submissions may match **root-repository** catalog records |
+| 6 | Root catalog records must **not** automatically absorb distinct explicit-subpath submissions into `already_published` |
+| 7 | Canonical among an identity group: earliest `createdAt`, then lowest issue number |
+
+### already_published
+
+- Match the live catalog deterministically by repository URL
+- Require subpath alignment when the issue (or catalog record) carries an explicit subpath
+- Unclear alignment (e.g. root issue vs catalog that only lists explicit subpaths) → `ambiguous_manual_review`
+- Multiple issues may be `already_published` for the same live skill; manifests keep `published_skill_ids`
+
+### Normalization details
+
 - Strip query, fragment, trailing slash, and `.git`
-- Lowercase GitHub `owner` / `repo`
+- Lowercase GitHub `owner` / `repo`; lowercase subpath for stable compare
 - Accept `https://`, `http://`, `git@github.com:`, `git+https://`, and `owner/repo` shorthand
-- **Do not** merge distinct repos by similar titles
-- **Monorepo subpath rule:** GitHub URLs with extra path segments (`/tree/...`, `/blob/...`, nested skill folders, etc.) normalize to **`https://github.com/owner/repo` only**. Subpaths are intentionally discarded so one repo identity matches the catalog; different repos never collapse together.
+- Non-`tree`/`blob` GitHub extras (`/issues/...`, etc.) collapse to repository root only
 
 ## Outputs (local; `out/` gitignored)
 
-- `backlog-cleanup-manifest.json` — per-issue disposition + reason + canonical mapping (full; do not commit)
-- `backlog-cleanup-summary.json` / `.csv` — aggregate counts (safe to commit if desired)
-- `backlog-execution-manifest.json` — issue numbers only, grouped by disposition (local/gitignored)
-- `backlog-rollback-manifest.json` — dry-run: empty `issue_numbers_touched` (no GitHub mutations)
+- `backlog-cleanup-manifest.json` — per-issue disposition + reason + normalized candidates (no issue bodies / PII; do not commit)
+- `backlog-cleanup-summary.json` / `.csv` — aggregate counts
+- `backlog-execution-manifest.json` — issue numbers only, grouped by disposition
+- `backlog-rollback-manifest.json` — dry-run: empty `issue_numbers_touched`
 
 Do not commit full issue dumps, bodies, emails, credentials, or PII.

--- a/operator/scripts/backlog/README.md
+++ b/operator/scripts/backlog/README.md
@@ -1,0 +1,17 @@
+# Backlog dry-run
+
+Deterministic Python tool to classify open submission issues. **No GitHub writes.**
+
+```bash
+python3 build_backlog_dry_run.py \
+  --issues /path/to/open-submissions.json \
+  --catalog /path/to/skills-catalog.json \
+  --out-dir ./out
+```
+
+Outputs (local; `out/` gitignored):
+- `backlog-cleanup-manifest.json` — per-issue disposition
+- `backlog-cleanup-summary.json` / `.csv` — aggregates
+- `backlog-rollback-manifest.json` — empty mutation list (dry-run)
+
+Do not commit full issue dumps or credentials.

--- a/operator/scripts/backlog/README.md
+++ b/operator/scripts/backlog/README.md
@@ -1,6 +1,7 @@
 # Backlog dry-run
 
 Deterministic Python tool to classify open submission issues. **No GitHub writes.**
+Dry-run only: reads local JSON dumps (issues + catalog) and writes local manifests.
 
 ```bash
 python3 build_backlog_dry_run.py \
@@ -9,9 +10,34 @@ python3 build_backlog_dry_run.py \
   --out-dir ./out
 ```
 
-Outputs (local; `out/` gitignored):
-- `backlog-cleanup-manifest.json` — per-issue disposition
-- `backlog-cleanup-summary.json` / `.csv` — aggregates
-- `backlog-rollback-manifest.json` — empty mutation list (dry-run)
+## Dispositions (mutually exclusive)
 
-Do not commit full issue dumps or credentials.
+| Disposition | Meaning |
+|---|---|
+| `canonical_actionable` | Earliest open issue (by `createdAt`, then lowest number) for a normalized source **not** in the live catalog |
+| `normalized_source_duplicate` | Later open issue sharing the same normalized source as a canonical sibling (GitHub untouched; mapping preserved) |
+| `already_published` | Normalized source already present in the live skills catalog |
+| `missing_source` | No extractable source URL in title/body |
+| `invalid_source` | URLs present but none normalize to a usable repo identity |
+
+Ambiguous / manual_review is reserved for future rules; current classifier does not emit it.
+
+## URL normalization (conservative)
+
+Implemented in `normalize.py`:
+
+- Prefer first GitHub repo URL found in body/title; else first non-empty normalized URL
+- Strip query, fragment, trailing slash, and `.git`
+- Lowercase GitHub `owner` / `repo`
+- Accept `https://`, `http://`, `git@github.com:`, `git+https://`, and `owner/repo` shorthand
+- **Do not** merge distinct repos by similar titles
+- **Monorepo subpath rule:** GitHub URLs with extra path segments (`/tree/...`, `/blob/...`, nested skill folders, etc.) normalize to **`https://github.com/owner/repo` only**. Subpaths are intentionally discarded so one repo identity matches the catalog; different repos never collapse together.
+
+## Outputs (local; `out/` gitignored)
+
+- `backlog-cleanup-manifest.json` — per-issue disposition + reason + canonical mapping (full; do not commit)
+- `backlog-cleanup-summary.json` / `.csv` — aggregate counts (safe to commit if desired)
+- `backlog-execution-manifest.json` — issue numbers only, grouped by disposition (local/gitignored)
+- `backlog-rollback-manifest.json` — dry-run: empty `issue_numbers_touched` (no GitHub mutations)
+
+Do not commit full issue dumps, bodies, emails, credentials, or PII.

--- a/operator/scripts/backlog/build_backlog_dry_run.py
+++ b/operator/scripts/backlog/build_backlog_dry_run.py
@@ -14,72 +14,284 @@ from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 
-from normalize import is_malformed_url, normalize_repo_url
+from normalize import is_malformed_url, normalize_source_identity
 
 URL_RE = re.compile(r"https?://[^\s\)\]\>\"']+", re.I)
 
 
-def extract_primary_source(title: str, body: str) -> str | None:
-    text = f"{body or ''}\n{title or ''}"
-    urls = [normalize_repo_url(u) for u in URL_RE.findall(text)]
-    urls = [u for u in urls if u]
-    for u in urls:
-        if "github.com" in u:
-            return u
-    return urls[0] if urls else None
+def extract_raw_url_strings(title: str, body: str) -> list[str]:
+    """Extract candidate http(s) URL strings from title+body (order preserved).
+
+    Body scanning collects http(s) URLs only, to avoid false positives from
+    path fragments inside tree/blob links. normalize_source_identity still
+    accepts owner/repo shorthand when given that form directly.
+    """
+    blob = f"{body or ''}\n{title or ''}"
+    found: list[str] = []
+    seen: set[str] = set()
+    for u in URL_RE.findall(blob):
+        u = u.rstrip(".,;:)")
+        u = u.rstrip("\u3002\uff0c\uff09\u3001")
+        if u not in seen:
+            seen.add(u)
+            found.append(u)
+    return found
+
+
+def extract_all_candidates(title: str, body: str) -> list[dict]:
+    """Return unique normalized source identities (deduped by identity_key, order stable)."""
+    out: list[dict] = []
+    seen_keys: set[str] = set()
+    for raw in extract_raw_url_strings(title, body):
+        ident = normalize_source_identity(raw)
+        if not ident:
+            continue
+        key = ident["identity_key"]
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        out.append(ident)
+    return out
+
+
+def build_catalog_index(cat: dict) -> dict[str, list[dict]]:
+    """Map repository URL -> list of {id, repo, subpath} catalog records.
+
+    Live catalog stores root repo_url only; subpath is None unless an explicit
+    tree/blob path appears in repo_url (rare).
+    """
+    by_repo: dict[str, list[dict]] = {}
+    for s in cat.get("skills") or []:
+        raw = None
+        for k in ("repo_url", "repo", "github", "repository"):
+            v = s.get(k)
+            if isinstance(v, dict):
+                v = v.get("url") or v.get("html_url")
+            if v:
+                raw = v
+                break
+        ident = normalize_source_identity(str(raw) if raw else None)
+        if not ident:
+            continue
+        rec = {
+            "id": s.get("id") or s.get("slug"),
+            "repo": ident["repo"],
+            "subpath": ident["subpath"],
+        }
+        by_repo.setdefault(ident["repo"], []).append(rec)
+    return by_repo
+
+
+def published_match(ident: dict, catalog_by_repo: dict[str, list[dict]]) -> tuple[str, list[str]]:
+    """Decide already_published support for a single identity.
+
+    Returns (status, skill_ids) where status is:
+      - "match": repository + subpath (when available) support already_published
+      - "none": not already_published (missing repo, or distinct explicit subpath
+        that must not be absorbed by a root catalog record)
+      - "conflict": alignment is unclear → ambiguous_manual_review
+    """
+    records = catalog_by_repo.get(ident["repo"]) or []
+    if not records:
+        return "none", []
+
+    issue_sub = ident["subpath"]  # None => root submission
+    if issue_sub is None:
+        # Root-repository submission may match root-repository catalog records.
+        root_ids = [r["id"] for r in records if r["subpath"] is None and r["id"]]
+        if root_ids:
+            return "match", root_ids
+        # Catalog has only explicit-subpath records; root must not auto-absorb them
+        return "conflict", [r["id"] for r in records if r["id"]]
+
+    # Explicit subpath: match only the same subpath. Distinct subpaths / root catalog
+    # records must NOT absorb this submission into already_published.
+    exact = [r["id"] for r in records if r["subpath"] == issue_sub and r["id"]]
+    if exact:
+        return "match", exact
+    return "none", []
+
+
+def classify_issue_row(
+    number: int,
+    created_at: str | None,
+    candidates: list[dict],
+    raw_urls: list[str],
+) -> dict:
+    """Pre-disposition row before group-level canonical assignment."""
+    if not candidates:
+        malformed = bool(raw_urls) and any(is_malformed_url(u) for u in raw_urls)
+        if malformed:
+            return {
+                "number": number,
+                "createdAt": created_at,
+                "status": "invalid_source",
+                "candidates": [],
+                "identity": None,
+            }
+        return {
+            "number": number,
+            "createdAt": created_at,
+            "status": "missing_source",
+            "candidates": [],
+            "identity": None,
+        }
+
+    keys = {c["identity_key"] for c in candidates}
+    if len(keys) > 1:
+        return {
+            "number": number,
+            "createdAt": created_at,
+            "status": "ambiguous",
+            "candidates": candidates,
+            "identity": None,
+            "reason": "competing normalized source identities",
+        }
+
+    return {
+        "number": number,
+        "createdAt": created_at,
+        "status": "ok",
+        "candidates": candidates,
+        "identity": candidates[0],
+    }
 
 
 def build(issues_path: Path, catalog_path: Path, out_dir: Path) -> dict:
     payload = json.loads(issues_path.read_text())
     issues = payload["issues"] if isinstance(payload, dict) else payload
     cat = json.loads(catalog_path.read_text())
-    published = set()
-    for s in cat.get("skills") or []:
-        for k in ("repo_url", "repo", "github", "repository"):
-            n = normalize_repo_url(s.get(k) if not isinstance(s.get(k), dict) else None)
-            if n:
-                published.add(n)
+    catalog_by_repo = build_catalog_index(cat)
 
     rows = []
     for issue in issues:
         title = issue.get("title") or ""
         body = issue.get("body") or ""
-        raw_urls = URL_RE.findall(body + "\n" + title)
-        norms = [normalize_repo_url(u) for u in raw_urls]
-        has_norm = any(norms)
-        malformed = bool(raw_urls) and not has_norm and any(is_malformed_url(u) for u in raw_urls)
-        src = extract_primary_source(title, body)
-        rows.append({
-            "number": issue["number"],
-            "createdAt": issue.get("createdAt"),
-            "source": src,
-            "malformed": malformed,
-            "missing": src is None and not malformed,
-        })
+        raw_urls = extract_raw_url_strings(title, body)
+        candidates = extract_all_candidates(title, body)
+        rows.append(
+            classify_issue_row(
+                issue["number"],
+                issue.get("createdAt"),
+                candidates,
+                raw_urls,
+            )
+        )
 
-    by_src: dict[str, list] = {}
+    # Group actionable identities for canonical selection
+    by_key: dict[str, list] = {}
     for r in rows:
-        if r["source"]:
-            by_src.setdefault(r["source"], []).append(r)
+        if r["status"] == "ok" and r["identity"]:
+            by_key.setdefault(r["identity"]["identity_key"], []).append(r)
 
     dispositions = []
     for r in rows:
-        if r["malformed"]:
-            dispositions.append({"number": r["number"], "disposition": "invalid_source", "reason": "malformed URL", "canonical_number": None, "source": None})
+        cand_keys = [c["identity_key"] for c in r["candidates"]]
+        if r["status"] == "invalid_source":
+            dispositions.append({
+                "number": r["number"],
+                "disposition": "invalid_source",
+                "reason": "malformed URL",
+                "canonical_number": None,
+                "source": None,
+                "subpath": None,
+                "candidates": [],
+                "published_skill_ids": [],
+            })
             continue
-        if r["missing"]:
-            dispositions.append({"number": r["number"], "disposition": "missing_source", "reason": "no extractable source URL", "canonical_number": None, "source": None})
+        if r["status"] == "missing_source":
+            dispositions.append({
+                "number": r["number"],
+                "disposition": "missing_source",
+                "reason": "no extractable source URL",
+                "canonical_number": None,
+                "source": None,
+                "subpath": None,
+                "candidates": [],
+                "published_skill_ids": [],
+            })
             continue
-        src = r["source"]
-        group = sorted(by_src[src], key=lambda x: (x["createdAt"] or "", x["number"]))
+        if r["status"] == "ambiguous":
+            dispositions.append({
+                "number": r["number"],
+                "disposition": "ambiguous_manual_review",
+                "reason": r.get("reason") or "competing normalized source identities",
+                "canonical_number": None,
+                "source": None,
+                "subpath": None,
+                "candidates": cand_keys,
+                "published_skill_ids": [],
+            })
+            continue
+
+        ident = r["identity"]
+        pub_status, skill_ids = published_match(ident, catalog_by_repo)
+        if pub_status == "conflict":
+            # Repository present but explicit subpath / root alignment unsupported
+            dispositions.append({
+                "number": r["number"],
+                "disposition": "ambiguous_manual_review",
+                "reason": (
+                    "published repository identity present but explicit subpath "
+                    "does not support already_published"
+                    if ident["subpath"]
+                    else "root submission conflicts with non-root catalog records for repository"
+                ),
+                "canonical_number": None,
+                "source": ident["repo"],
+                "subpath": ident["subpath"],
+                "candidates": cand_keys,
+                "published_skill_ids": skill_ids,
+            })
+            continue
+
+        if pub_status == "match":
+            # Multiple issues may be already_published for the same live skill
+            group = sorted(
+                by_key[ident["identity_key"]],
+                key=lambda x: (x["createdAt"] or "", x["number"]),
+            )
+            canonical = group[0]
+            dispositions.append({
+                "number": r["number"],
+                "disposition": "already_published",
+                "reason": "repository identity and subpath support match to live catalog",
+                "canonical_number": canonical["number"],
+                "source": ident["repo"],
+                "subpath": ident["subpath"],
+                "candidates": cand_keys,
+                "published_skill_ids": skill_ids,
+            })
+            continue
+
+        # Not published — canonical / duplicate by identity_key (repo + subpath)
+        group = sorted(
+            by_key[ident["identity_key"]],
+            key=lambda x: (x["createdAt"] or "", x["number"]),
+        )
         canonical = group[0]
-        if src in published:
-            dispositions.append({"number": r["number"], "disposition": "already_published", "reason": "normalized source already in catalog", "canonical_number": canonical["number"], "source": src})
-            continue
         if r["number"] == canonical["number"]:
-            dispositions.append({"number": r["number"], "disposition": "canonical_actionable", "reason": "earliest valid issue for normalized source", "canonical_number": r["number"], "source": src})
+            dispositions.append({
+                "number": r["number"],
+                "disposition": "canonical_actionable",
+                "reason": "earliest valid issue for normalized source identity",
+                "canonical_number": r["number"],
+                "source": ident["repo"],
+                "subpath": ident["subpath"],
+                "candidates": cand_keys,
+                "published_skill_ids": [],
+            })
         else:
-            dispositions.append({"number": r["number"], "disposition": "normalized_source_duplicate", "reason": f"duplicate of #{canonical['number']}", "canonical_number": canonical["number"], "source": src})
+            dispositions.append({
+                "number": r["number"],
+                "disposition": "normalized_source_duplicate",
+                "reason": f"duplicate of #{canonical['number']}",
+                "canonical_number": canonical["number"],
+                "source": ident["repo"],
+                "subpath": ident["subpath"],
+                "candidates": cand_keys,
+                "published_skill_ids": [],
+            })
 
     counts = Counter(d["disposition"] for d in dispositions)
     generated_at = datetime.now(timezone.utc).isoformat()
@@ -87,11 +299,25 @@ def build(issues_path: Path, catalog_path: Path, out_dir: Path) -> dict:
     (out_dir / "backlog-cleanup-manifest.json").write_text(json.dumps({
         "generated_at": generated_at,
         "issue_count": len(issues),
+        "catalog_skill_count": len(cat.get("skills") or []),
         "disposition_counts": dict(counts),
         "items": dispositions,
         "criteria": {
             "canonical": "earliest createdAt, then lowest number",
-            "dedupe_key": "normalized_repo_url from issue body/title",
+            "dedupe_key": "normalized repo URL + explicit tree/blob subpath when present",
+            "multi_url": (
+                "all candidate URLs extracted; equivalent identities classify normally; "
+                "competing identities => ambiguous_manual_review"
+            ),
+            "monorepo": (
+                "owner/repo is repository identity; explicit tree/blob subpath is secondary "
+                "skill identity; distinct subpaths are not duplicates; root submissions may "
+                "match root catalog records but do not absorb distinct explicit subpaths"
+            ),
+            "already_published": (
+                "requires repository identity match and subpath alignment when available; "
+                "conflicts => ambiguous_manual_review; multiple issues may map to one skill"
+            ),
         },
     }, indent=2) + "\n")
     by_disp: dict[str, list[int]] = {}
@@ -114,7 +340,12 @@ def build(issues_path: Path, catalog_path: Path, out_dir: Path) -> dict:
         w.writerow(["disposition", "count"])
         for k, v in sorted(counts.items()):
             w.writerow([k, v])
-    summary = {"generated_at": generated_at, "counts": dict(counts), "total": len(dispositions)}
+    summary = {
+        "generated_at": generated_at,
+        "counts": dict(counts),
+        "total": len(dispositions),
+        "catalog_skill_count": len(cat.get("skills") or []),
+    }
     (out_dir / "backlog-cleanup-summary.json").write_text(json.dumps(summary, indent=2) + "\n")
     return summary
 

--- a/operator/scripts/backlog/build_backlog_dry_run.py
+++ b/operator/scripts/backlog/build_backlog_dry_run.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Deterministic backlog dedupe dry-run for ProSkills submissions.
+
+No GitHub mutations. No AI per issue. No fetching/executing submitted code.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+from normalize import is_malformed_url, normalize_repo_url
+
+URL_RE = re.compile(r"https?://[^\s\)\]\>\"']+", re.I)
+
+
+def extract_primary_source(title: str, body: str) -> str | None:
+    text = f"{body or ''}\n{title or ''}"
+    urls = [normalize_repo_url(u) for u in URL_RE.findall(text)]
+    urls = [u for u in urls if u]
+    for u in urls:
+        if "github.com" in u:
+            return u
+    return urls[0] if urls else None
+
+
+def build(issues_path: Path, catalog_path: Path, out_dir: Path) -> dict:
+    payload = json.loads(issues_path.read_text())
+    issues = payload["issues"] if isinstance(payload, dict) else payload
+    cat = json.loads(catalog_path.read_text())
+    published = set()
+    for s in cat.get("skills") or []:
+        for k in ("repo_url", "repo", "github", "repository"):
+            n = normalize_repo_url(s.get(k) if not isinstance(s.get(k), dict) else None)
+            if n:
+                published.add(n)
+
+    rows = []
+    for issue in issues:
+        title = issue.get("title") or ""
+        body = issue.get("body") or ""
+        raw_urls = URL_RE.findall(body + "\n" + title)
+        norms = [normalize_repo_url(u) for u in raw_urls]
+        has_norm = any(norms)
+        malformed = bool(raw_urls) and not has_norm and any(is_malformed_url(u) for u in raw_urls)
+        src = extract_primary_source(title, body)
+        rows.append({
+            "number": issue["number"],
+            "createdAt": issue.get("createdAt"),
+            "source": src,
+            "malformed": malformed,
+            "missing": src is None and not malformed,
+        })
+
+    by_src: dict[str, list] = {}
+    for r in rows:
+        if r["source"]:
+            by_src.setdefault(r["source"], []).append(r)
+
+    dispositions = []
+    for r in rows:
+        if r["malformed"]:
+            dispositions.append({"number": r["number"], "disposition": "invalid_source", "reason": "malformed URL", "canonical_number": None, "source": None})
+            continue
+        if r["missing"]:
+            dispositions.append({"number": r["number"], "disposition": "missing_source", "reason": "no extractable source URL", "canonical_number": None, "source": None})
+            continue
+        src = r["source"]
+        group = sorted(by_src[src], key=lambda x: (x["createdAt"] or "", x["number"]))
+        canonical = group[0]
+        if src in published:
+            dispositions.append({"number": r["number"], "disposition": "already_published", "reason": "normalized source already in catalog", "canonical_number": canonical["number"], "source": src})
+            continue
+        if r["number"] == canonical["number"]:
+            dispositions.append({"number": r["number"], "disposition": "canonical_actionable", "reason": "earliest valid issue for normalized source", "canonical_number": r["number"], "source": src})
+        else:
+            dispositions.append({"number": r["number"], "disposition": "normalized_source_duplicate", "reason": f"duplicate of #{canonical['number']}", "canonical_number": canonical["number"], "source": src})
+
+    counts = Counter(d["disposition"] for d in dispositions)
+    generated_at = datetime.now(timezone.utc).isoformat()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "backlog-cleanup-manifest.json").write_text(json.dumps({
+        "generated_at": generated_at,
+        "issue_count": len(issues),
+        "disposition_counts": dict(counts),
+        "items": dispositions,
+        "criteria": {
+            "canonical": "earliest createdAt, then lowest number",
+            "dedupe_key": "normalized_repo_url from issue body/title",
+        },
+    }, indent=2) + "\n")
+    (out_dir / "backlog-rollback-manifest.json").write_text(json.dumps({
+        "generated_at": generated_at,
+        "note": "dry-run only — no GitHub mutations performed",
+        "issue_numbers_touched": [],
+    }, indent=2) + "\n")
+    with (out_dir / "backlog-cleanup-summary.csv").open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["disposition", "count"])
+        for k, v in sorted(counts.items()):
+            w.writerow([k, v])
+    summary = {"generated_at": generated_at, "counts": dict(counts), "total": len(dispositions)}
+    (out_dir / "backlog-cleanup-summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    return summary
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--issues", type=Path, required=True)
+    ap.add_argument("--catalog", type=Path, required=True)
+    ap.add_argument("--out-dir", type=Path, required=True)
+    args = ap.parse_args()
+    print(json.dumps(build(args.issues, args.catalog, args.out_dir), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/operator/scripts/backlog/build_backlog_dry_run.py
+++ b/operator/scripts/backlog/build_backlog_dry_run.py
@@ -94,6 +94,16 @@ def build(issues_path: Path, catalog_path: Path, out_dir: Path) -> dict:
             "dedupe_key": "normalized_repo_url from issue body/title",
         },
     }, indent=2) + "\n")
+    by_disp: dict[str, list[int]] = {}
+    for d in dispositions:
+        by_disp.setdefault(d["disposition"], []).append(d["number"])
+    for k in by_disp:
+        by_disp[k] = sorted(by_disp[k])
+    (out_dir / "backlog-execution-manifest.json").write_text(json.dumps({
+        "generated_at": generated_at,
+        "note": "dry-run plan — issue numbers only; no GitHub mutations",
+        "issue_numbers_by_disposition": by_disp,
+    }, indent=2) + "\n")
     (out_dir / "backlog-rollback-manifest.json").write_text(json.dumps({
         "generated_at": generated_at,
         "note": "dry-run only — no GitHub mutations performed",

--- a/operator/scripts/backlog/disposition-counts.json
+++ b/operator/scripts/backlog/disposition-counts.json
@@ -1,0 +1,23 @@
+{
+  "instruction": 19,
+  "catalog_skill_count": 595,
+  "issue_count": 3159,
+  "disposition_counts": {
+    "canonical_actionable": 2036,
+    "normalized_source_duplicate": 770,
+    "already_published": 331,
+    "missing_source": 10,
+    "invalid_source": 0,
+    "ambiguous_manual_review": 12
+  },
+  "transition_matrix_from_i18": {
+    "canonical_actionable -> canonical_actionable": 2034,
+    "normalized_source_duplicate -> normalized_source_duplicate": 770,
+    "already_published -> already_published": 331,
+    "missing_source -> missing_source": 10,
+    "canonical_actionable -> ambiguous_manual_review": 7,
+    "already_published -> ambiguous_manual_review": 5,
+    "already_published -> canonical_actionable": 2
+  },
+  "note": "Anonymized aggregates only; full manifests stay local/gitignored."
+}

--- a/operator/scripts/backlog/normalize.py
+++ b/operator/scripts/backlog/normalize.py
@@ -10,10 +10,32 @@ GITHUB_HOSTS = {"github.com", "www.github.com"}
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 _GH_SSH = re.compile(r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$")
 _GH_SHORT = re.compile(r"^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)(?:\.git)?$")
+_TREE_BLOB = {"tree", "blob"}
 
 
-def normalize_repo_url(raw: str | None) -> str | None:
-    """Return canonical https://github.com/owner/repo or https URL, or None if empty/invalid."""
+def _clean_subpath(parts: list[str]) -> str | None:
+    """Normalize explicit subpath segments; empty -> None (root)."""
+    if not parts:
+        return None
+    cleaned = "/".join(p for p in parts if p).strip("/")
+    if not cleaned:
+        return None
+    # Deterministic compare: lowercase path segments
+    return cleaned.lower()
+
+
+def normalize_source_identity(raw: str | None) -> dict | None:
+    """Parse a source URL into repository + optional explicit subpath identity.
+
+    Returns dict with:
+      repo: canonical https://github.com/owner/repo (or non-GH https URL)
+      subpath: explicit tree/blob path after ref, or None for root-repo identity
+      identity_key: stable dedupe key "repo::subpath" (subpath empty for root)
+      display: human-readable source string (repo or repo/tree/.../subpath)
+
+    Competing identities differ by identity_key. Root and an explicit subpath in
+    the same monorepo are distinct identities.
+    """
     if raw is None:
         return None
     u = str(raw).strip()
@@ -22,18 +44,28 @@ def normalize_repo_url(raw: str | None) -> str | None:
 
     m = _GH_SSH.match(u)
     if m:
-        owner, repo = m.group(1), m.group(2)
-        return f"https://github.com/{owner.lower()}/{repo.removesuffix('.git').lower()}"
+        owner, repo = m.group(1).lower(), m.group(2).removesuffix(".git").lower()
+        repo_url = f"https://github.com/{owner}/{repo}"
+        return {
+            "repo": repo_url,
+            "subpath": None,
+            "identity_key": f"{repo_url}::",
+            "display": repo_url,
+        }
 
-    # owner/repo shorthand
     if "://" not in u and _GH_SHORT.match(u):
         owner, repo = _GH_SHORT.match(u).groups()
-        return f"https://github.com/{owner.lower()}/{repo.removesuffix('.git').lower()}"
+        repo_url = f"https://github.com/{owner.lower()}/{repo.removesuffix('.git').lower()}"
+        return {
+            "repo": repo_url,
+            "subpath": None,
+            "identity_key": f"{repo_url}::",
+            "display": repo_url,
+        }
 
     if u.startswith("git+"):
         u = u[4:]
 
-    # ensure scheme for parsing
     trial = u if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", u) else "https://" + u
     try:
         p = urlparse(trial)
@@ -45,7 +77,6 @@ def normalize_repo_url(raw: str | None) -> str | None:
         return None
 
     path = (p.path or "").rstrip("/")
-    # drop .git
     if path.endswith(".git"):
         path = path[:-4]
 
@@ -54,20 +85,50 @@ def normalize_repo_url(raw: str | None) -> str | None:
         if len(parts) < 2:
             return None
         owner, repo = parts[0].lower(), parts[1].lower()
-        # strip github tree/blob extras — keep only owner/repo
-        return f"https://github.com/{owner}/{repo}"
+        repo_url = f"https://github.com/{owner}/{repo}"
+        subpath = None
+        if len(parts) >= 4 and parts[2].lower() in _TREE_BLOB:
+            # owner/repo/tree|blob/<ref>/<subpath...>
+            subpath = _clean_subpath(parts[4:])
+        elif len(parts) > 2 and parts[2].lower() not in _TREE_BLOB:
+            # Non tree/blob extras (issues, pulls, etc.) → repository root only
+            subpath = None
+        display = repo_url if not subpath else f"{repo_url}/tree/<ref>/{subpath}"
+        return {
+            "repo": repo_url,
+            "subpath": subpath,
+            "identity_key": f"{repo_url}::{subpath or ''}",
+            "display": display,
+        }
 
-    # non-github: scheme + host + path, no query/fragment, lower host
-    clean = urlunparse(("https" if p.scheme in {"http", "https"} else p.scheme, host, path, "", "", ""))
+    clean = urlunparse(
+        ("https" if p.scheme in {"http", "https"} else p.scheme, host, path, "", "", "")
+    )
     if not path or path == "/":
         return None
-    return clean.rstrip("/")
+    clean = clean.rstrip("/")
+    return {
+        "repo": clean,
+        "subpath": None,
+        "identity_key": f"{clean}::",
+        "display": clean,
+    }
+
+
+def normalize_repo_url(raw: str | None) -> str | None:
+    """Return canonical repository URL only (owner/repo), or None if empty/invalid.
+
+    Explicit tree/blob subpaths are stripped here; use normalize_source_identity
+    when secondary skill identity (subpath) must be preserved.
+    """
+    ident = normalize_source_identity(raw)
+    return ident["repo"] if ident else None
 
 
 def is_malformed_url(raw: str | None) -> bool:
     if raw is None or not str(raw).strip():
         return False
-    return normalize_repo_url(raw) is None
+    return normalize_source_identity(raw) is None
 
 
 def slugify(text: str, fallback: str = "skill") -> str:
@@ -80,7 +141,6 @@ def slugify(text: str, fallback: str = "skill") -> str:
 
 
 def stable_id_from_repo(norm_repo: str) -> str:
-    # github.com/owner/repo -> owner-repo
     if "github.com/" in norm_repo:
         rest = norm_repo.split("github.com/", 1)[1]
         return slugify(rest.replace("/", "-"))

--- a/operator/scripts/backlog/normalize.py
+++ b/operator/scripts/backlog/normalize.py
@@ -1,0 +1,114 @@
+"""Deterministic URL / identity helpers for ProSkills catalog remediation."""
+from __future__ import annotations
+
+import hashlib
+import re
+from urllib.parse import urlparse, urlunparse
+
+GITHUB_HOSTS = {"github.com", "www.github.com"}
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_GH_SSH = re.compile(r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$")
+_GH_SHORT = re.compile(r"^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)(?:\.git)?$")
+
+
+def normalize_repo_url(raw: str | None) -> str | None:
+    """Return canonical https://github.com/owner/repo or https URL, or None if empty/invalid."""
+    if raw is None:
+        return None
+    u = str(raw).strip()
+    if not u or u.lower() in {"none", "null", "undefined", "n/a"}:
+        return None
+
+    m = _GH_SSH.match(u)
+    if m:
+        owner, repo = m.group(1), m.group(2)
+        return f"https://github.com/{owner.lower()}/{repo.removesuffix('.git').lower()}"
+
+    # owner/repo shorthand
+    if "://" not in u and _GH_SHORT.match(u):
+        owner, repo = _GH_SHORT.match(u).groups()
+        return f"https://github.com/{owner.lower()}/{repo.removesuffix('.git').lower()}"
+
+    if u.startswith("git+"):
+        u = u[4:]
+
+    # ensure scheme for parsing
+    trial = u if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", u) else "https://" + u
+    try:
+        p = urlparse(trial)
+    except Exception:
+        return None
+
+    host = (p.hostname or "").lower()
+    if not host:
+        return None
+
+    path = (p.path or "").rstrip("/")
+    # drop .git
+    if path.endswith(".git"):
+        path = path[:-4]
+
+    if host in GITHUB_HOSTS:
+        parts = [x for x in path.split("/") if x]
+        if len(parts) < 2:
+            return None
+        owner, repo = parts[0].lower(), parts[1].lower()
+        # strip github tree/blob extras — keep only owner/repo
+        return f"https://github.com/{owner}/{repo}"
+
+    # non-github: scheme + host + path, no query/fragment, lower host
+    clean = urlunparse(("https" if p.scheme in {"http", "https"} else p.scheme, host, path, "", "", ""))
+    if not path or path == "/":
+        return None
+    return clean.rstrip("/")
+
+
+def is_malformed_url(raw: str | None) -> bool:
+    if raw is None or not str(raw).strip():
+        return False
+    return normalize_repo_url(raw) is None
+
+
+def slugify(text: str, fallback: str = "skill") -> str:
+    s = (text or "").strip().lower()
+    s = _SLUG_RE.sub("-", s).strip("-")
+    s = re.sub(r"-{2,}", "-", s)
+    if not s or s == "undefined":
+        s = fallback
+    return s[:80].rstrip("-") or fallback
+
+
+def stable_id_from_repo(norm_repo: str) -> str:
+    # github.com/owner/repo -> owner-repo
+    if "github.com/" in norm_repo:
+        rest = norm_repo.split("github.com/", 1)[1]
+        return slugify(rest.replace("/", "-"))
+    h = hashlib.sha256(norm_repo.encode()).hexdigest()[:10]
+    return slugify(urlparse(norm_repo).path.strip("/").replace("/", "-") or f"ext-{h}")
+
+
+def stable_id_from_name(name: str, index: int) -> str:
+    base = slugify(name or f"skill-{index}")
+    return f"{base}-{index}"
+
+
+def pick_source_fields(row: dict) -> tuple[str | None, str | None, str | None, str | None]:
+    """Return (raw_repo, name, raw_category, existing_id/slug hints)."""
+    raw_repo = row.get("repo_url") or row.get("repo") or row.get("github") or row.get("repository")
+    if isinstance(raw_repo, dict):
+        raw_repo = raw_repo.get("url") or raw_repo.get("html_url")
+    name = row.get("name") or row.get("title") or ""
+    cat = row.get("category")
+    if not cat and isinstance(row.get("categories"), list) and row["categories"]:
+        cat = row["categories"][0]
+    if isinstance(cat, list) and cat:
+        cat = cat[0]
+    existing_id = row.get("id") if isinstance(row.get("id"), str) else None
+    existing_slug = row.get("slug") if isinstance(row.get("slug"), str) else None
+    return (
+        str(raw_repo).strip() if raw_repo else None,
+        str(name).strip() if name else None,
+        str(cat).strip() if cat else None,
+        (existing_id or existing_slug or None),
+    )

--- a/operator/scripts/backlog/tests/test_backlog_dry_run.py
+++ b/operator/scripts/backlog/tests/test_backlog_dry_run.py
@@ -6,8 +6,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
-from build_backlog_dry_run import build  # noqa: E402
-from normalize import normalize_repo_url, is_malformed_url  # noqa: E402
+from build_backlog_dry_run import build, extract_all_candidates  # noqa: E402
+from normalize import (  # noqa: E402
+    normalize_repo_url,
+    normalize_source_identity,
+    is_malformed_url,
+)
 
 
 class NormalizeTests(unittest.TestCase):
@@ -21,20 +25,44 @@ class NormalizeTests(unittest.TestCase):
             "https://github.com/owner/repo",
         )
 
-    def test_monorepo_subpath_collapses_to_owner_repo(self):
+    def test_monorepo_subpath_preserved_as_secondary_identity(self):
+        ident = normalize_source_identity(
+            "https://github.com/owner/repo/tree/main/skills/foo"
+        )
+        self.assertEqual(ident["repo"], "https://github.com/owner/repo")
+        self.assertEqual(ident["subpath"], "skills/foo")
+        self.assertEqual(ident["identity_key"], "https://github.com/owner/repo::skills/foo")
+        # repo-only helper still returns owner/repo
         self.assertEqual(
             normalize_repo_url("https://github.com/owner/repo/tree/main/skills/foo"),
             "https://github.com/owner/repo",
         )
-        self.assertEqual(
-            normalize_repo_url("https://github.com/owner/repo/blob/main/README.md"),
-            "https://github.com/owner/repo",
+        blob = normalize_source_identity(
+            "https://github.com/owner/repo/blob/main/skills/bar/SKILL.md"
         )
+        self.assertEqual(blob["subpath"], "skills/bar/skill.md")
 
     def test_distinct_repos_not_merged(self):
         a = normalize_repo_url("https://github.com/owner/repo-a")
         b = normalize_repo_url("https://github.com/owner/repo-b")
         self.assertNotEqual(a, b)
+
+    def test_distinct_subpaths_not_same_identity(self):
+        a = normalize_source_identity(
+            "https://github.com/owner/mono/tree/main/skills/a"
+        )
+        b = normalize_source_identity(
+            "https://github.com/owner/mono/tree/main/skills/b"
+        )
+        self.assertEqual(a["repo"], b["repo"])
+        self.assertNotEqual(a["identity_key"], b["identity_key"])
+
+    def test_root_vs_explicit_subpath_distinct(self):
+        root = normalize_source_identity("https://github.com/owner/mono")
+        sub = normalize_source_identity(
+            "https://github.com/owner/mono/tree/main/skills/a"
+        )
+        self.assertNotEqual(root["identity_key"], sub["identity_key"])
 
     def test_ssh_and_shorthand(self):
         self.assertEqual(
@@ -51,22 +79,50 @@ class NormalizeTests(unittest.TestCase):
         self.assertIsNone(normalize_repo_url("not a url"))
 
 
+class CandidateExtractionTests(unittest.TestCase):
+    def test_multiple_equivalent_urls(self):
+        body = (
+            "https://github.com/Owner/Repo\n"
+            "https://github.com/owner/repo.git\n"
+            "https://GITHUB.com/owner/repo/"
+        )
+        cands = extract_all_candidates("t", body)
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(cands[0]["repo"], "https://github.com/owner/repo")
+
+    def test_multiple_competing_urls(self):
+        body = (
+            "https://github.com/owner/repo-a\n"
+            "https://github.com/owner/repo-b"
+        )
+        cands = extract_all_candidates("t", body)
+        self.assertEqual(len(cands), 2)
+
+
 class BacklogDryRunTests(unittest.TestCase):
-    def test_dispositions(self):
-        issues = {
-            "issues": [
-                {"number": 1, "title": "[submission] a", "body": "https://github.com/o/a", "createdAt": "2026-01-01T00:00:00Z"},
-                {"number": 2, "title": "[submission] a dup", "body": "https://github.com/o/a", "createdAt": "2026-01-02T00:00:00Z"},
-                {"number": 3, "title": "[submission] published", "body": "https://github.com/o/pub", "createdAt": "2026-01-01T00:00:00Z"},
-                {"number": 4, "title": "[submission] none", "body": "no url", "createdAt": "2026-01-01T00:00:00Z"},
-                {"number": 5, "title": "[submission] bad", "body": "https://github.com/onlyowner", "createdAt": "2026-01-01T00:00:00Z"},
-            ]
-        }
-        catalog = {"skills": [{"repo_url": "https://github.com/o/pub"}]}
+    def _run(self, issues, catalog):
         with tempfile.TemporaryDirectory() as td:
             td = Path(td)
-            (td / "issues.json").write_text(json.dumps(issues))
-            (td / "cat.json").write_text(json.dumps(catalog))
+            (td / "issues.json").write_text(json.dumps({"issues": issues}))
+            (td / "cat.json").write_text(json.dumps({"skills": catalog}))
+            out = td / "out"
+            summary = build(td / "issues.json", td / "cat.json", out)
+            manifest = json.loads((out / "backlog-cleanup-manifest.json").read_text())
+            return summary, manifest, out
+
+    def test_basic_dispositions(self):
+        issues = [
+            {"number": 1, "title": "[submission] a", "body": "https://github.com/o/a", "createdAt": "2026-01-01T00:00:00Z"},
+            {"number": 2, "title": "[submission] a dup", "body": "https://github.com/o/a", "createdAt": "2026-01-02T00:00:00Z"},
+            {"number": 3, "title": "[submission] published", "body": "https://github.com/o/pub", "createdAt": "2026-01-01T00:00:00Z"},
+            {"number": 4, "title": "[submission] none", "body": "no url", "createdAt": "2026-01-01T00:00:00Z"},
+            {"number": 5, "title": "[submission] bad", "body": "https://github.com/onlyowner", "createdAt": "2026-01-01T00:00:00Z"},
+        ]
+        catalog = [{"id": "pub", "repo_url": "https://github.com/o/pub"}]
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            (td / "issues.json").write_text(json.dumps({"issues": issues}))
+            (td / "cat.json").write_text(json.dumps({"skills": catalog}))
             out = td / "out"
             summary = build(td / "issues.json", td / "cat.json", out)
             self.assertEqual(summary["total"], 5)
@@ -76,22 +132,175 @@ class BacklogDryRunTests(unittest.TestCase):
             self.assertEqual(summary["counts"].get("missing_source"), 1)
             self.assertEqual(summary["counts"].get("invalid_source"), 1)
             exec_m = json.loads((out / "backlog-execution-manifest.json").read_text())
-            self.assertIn("issue_numbers_by_disposition", exec_m)
             self.assertEqual(exec_m["issue_numbers_by_disposition"]["canonical_actionable"], [1])
             rb = json.loads((out / "backlog-rollback-manifest.json").read_text())
             self.assertEqual(rb["issue_numbers_touched"], [])
 
+    def test_two_skills_different_folders_same_monorepo(self):
+        issues = [
+            {
+                "number": 10,
+                "title": "skill a",
+                "body": "https://github.com/acme/mono/tree/main/skills/alpha",
+                "createdAt": "2026-01-01T00:00:00Z",
+            },
+            {
+                "number": 11,
+                "title": "skill b",
+                "body": "https://github.com/acme/mono/tree/main/skills/beta",
+                "createdAt": "2026-01-02T00:00:00Z",
+            },
+        ]
+        summary, manifest, _ = self._run(issues, [])
+        by_n = {i["number"]: i for i in manifest["items"]}
+        self.assertEqual(by_n[10]["disposition"], "canonical_actionable")
+        self.assertEqual(by_n[11]["disposition"], "canonical_actionable")
+        self.assertNotEqual(by_n[10]["subpath"], by_n[11]["subpath"])
+
+    def test_root_repo_versus_explicit_subpath(self):
+        issues = [
+            {
+                "number": 20,
+                "title": "root",
+                "body": "https://github.com/acme/mono",
+                "createdAt": "2026-01-01T00:00:00Z",
+            },
+            {
+                "number": 21,
+                "title": "sub",
+                "body": "https://github.com/acme/mono/tree/main/skills/alpha",
+                "createdAt": "2026-01-02T00:00:00Z",
+            },
+        ]
+        summary, manifest, _ = self._run(issues, [])
+        by_n = {i["number"]: i for i in manifest["items"]}
+        self.assertEqual(by_n[20]["disposition"], "canonical_actionable")
+        self.assertEqual(by_n[21]["disposition"], "canonical_actionable")
+        self.assertIsNone(by_n[20]["subpath"])
+        self.assertEqual(by_n[21]["subpath"], "skills/alpha")
+
+    def test_multiple_equivalent_urls_classify_normally(self):
+        issues = [
+            {
+                "number": 30,
+                "title": "eq",
+                "body": (
+                    "see https://github.com/Owner/Repo and "
+                    "https://github.com/owner/repo.git"
+                ),
+                "createdAt": "2026-01-01T00:00:00Z",
+            },
+            {
+                "number": 31,
+                "title": "eq dup",
+                "body": "https://github.com/owner/repo",
+                "createdAt": "2026-01-02T00:00:00Z",
+            },
+        ]
+        summary, manifest, _ = self._run(issues, [])
+        by_n = {i["number"]: i for i in manifest["items"]}
+        self.assertEqual(by_n[30]["disposition"], "canonical_actionable")
+        self.assertEqual(by_n[31]["disposition"], "normalized_source_duplicate")
+        self.assertEqual(by_n[31]["canonical_number"], 30)
+
+    def test_multiple_competing_urls_ambiguous(self):
+        issues = [
+            {
+                "number": 40,
+                "title": "compete",
+                "body": (
+                    "https://github.com/owner/repo-a\n"
+                    "https://github.com/owner/repo-b"
+                ),
+                "createdAt": "2026-01-01T00:00:00Z",
+            },
+        ]
+        summary, manifest, _ = self._run(issues, [])
+        item = manifest["items"][0]
+        self.assertEqual(item["disposition"], "ambiguous_manual_review")
+        self.assertEqual(len(item["candidates"]), 2)
+        # no body / PII fields
+        self.assertNotIn("body", item)
+        self.assertNotIn("title", item)
+
+    def test_published_matching_and_nonmatching_subpaths(self):
+        catalog = [{"id": "pub-root", "repo_url": "https://github.com/acme/published"}]
+        issues = [
+            {
+                "number": 50,
+                "title": "match root",
+                "body": "https://github.com/acme/published",
+                "createdAt": "2026-01-01T00:00:00Z",
+            },
+            {
+                "number": 51,
+                "title": "nonmatching subpath",
+                "body": "https://github.com/acme/published/tree/main/skills/other",
+                "createdAt": "2026-01-02T00:00:00Z",
+            },
+            {
+                "number": 52,
+                "title": "another already published",
+                "body": "https://github.com/acme/published.git",
+                "createdAt": "2026-01-03T00:00:00Z",
+            },
+        ]
+        summary, manifest, _ = self._run(issues, catalog)
+        by_n = {i["number"]: i for i in manifest["items"]}
+        self.assertEqual(by_n[50]["disposition"], "already_published")
+        self.assertEqual(by_n[50]["published_skill_ids"], ["pub-root"])
+        # distinct explicit subpath must not be absorbed by root catalog record
+        self.assertEqual(by_n[51]["disposition"], "canonical_actionable")
+        self.assertEqual(by_n[51]["subpath"], "skills/other")
+        # multiple issues may be already_published for same skill
+        self.assertEqual(by_n[52]["disposition"], "already_published")
+        self.assertEqual(by_n[52]["published_skill_ids"], ["pub-root"])
+
+    def test_deterministic_canonical_selection(self):
+        issues = [
+            {
+                "number": 62,
+                "title": "later number earlier time wins? no — time first",
+                "body": "https://github.com/o/x",
+                "createdAt": "2026-01-02T00:00:00Z",
+            },
+            {
+                "number": 61,
+                "title": "earlier",
+                "body": "https://github.com/o/x",
+                "createdAt": "2026-01-01T00:00:00Z",
+            },
+            {
+                "number": 60,
+                "title": "same time lower number",
+                "body": "https://github.com/o/y",
+                "createdAt": "2026-01-01T00:00:00Z",
+            },
+            {
+                "number": 63,
+                "title": "same time higher number",
+                "body": "https://github.com/o/y",
+                "createdAt": "2026-01-01T00:00:00Z",
+            },
+        ]
+        summary, manifest, _ = self._run(issues, [])
+        by_n = {i["number"]: i for i in manifest["items"]}
+        self.assertEqual(by_n[61]["disposition"], "canonical_actionable")
+        self.assertEqual(by_n[62]["disposition"], "normalized_source_duplicate")
+        self.assertEqual(by_n[62]["canonical_number"], 61)
+        self.assertEqual(by_n[60]["disposition"], "canonical_actionable")
+        self.assertEqual(by_n[63]["disposition"], "normalized_source_duplicate")
+        self.assertEqual(by_n[63]["canonical_number"], 60)
+
     def test_idempotent_except_timestamp(self):
-        issues = {
-            "issues": [
-                {"number": 1, "title": "a", "body": "https://github.com/o/a", "createdAt": "2026-01-01T00:00:00Z"},
-            ]
-        }
-        catalog = {"skills": []}
+        issues = [
+            {"number": 1, "title": "a", "body": "https://github.com/o/a", "createdAt": "2026-01-01T00:00:00Z"},
+        ]
+        catalog = []
         with tempfile.TemporaryDirectory() as td:
             td = Path(td)
-            (td / "issues.json").write_text(json.dumps(issues))
-            (td / "cat.json").write_text(json.dumps(catalog))
+            (td / "issues.json").write_text(json.dumps({"issues": issues}))
+            (td / "cat.json").write_text(json.dumps({"skills": catalog}))
             out1, out2 = td / "o1", td / "o2"
             build(td / "issues.json", td / "cat.json", out1)
             build(td / "issues.json", td / "cat.json", out2)

--- a/operator/scripts/backlog/tests/test_backlog_dry_run.py
+++ b/operator/scripts/backlog/tests/test_backlog_dry_run.py
@@ -1,0 +1,37 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from build_backlog_dry_run import build  # noqa: E402
+
+
+class BacklogDryRunTests(unittest.TestCase):
+    def test_dispositions(self):
+        issues = {
+            "issues": [
+                {"number": 1, "title": "[submission] a", "body": "https://github.com/o/a", "createdAt": "2026-01-01T00:00:00Z"},
+                {"number": 2, "title": "[submission] a dup", "body": "https://github.com/o/a", "createdAt": "2026-01-02T00:00:00Z"},
+                {"number": 3, "title": "[submission] published", "body": "https://github.com/o/pub", "createdAt": "2026-01-01T00:00:00Z"},
+                {"number": 4, "title": "[submission] none", "body": "no url", "createdAt": "2026-01-01T00:00:00Z"},
+            ]
+        }
+        catalog = {"skills": [{"repo_url": "https://github.com/o/pub"}]}
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            (td / "issues.json").write_text(json.dumps(issues))
+            (td / "cat.json").write_text(json.dumps(catalog))
+            out = td / "out"
+            summary = build(td / "issues.json", td / "cat.json", out)
+            self.assertEqual(summary["total"], 4)
+            self.assertEqual(summary["counts"].get("canonical_actionable"), 1)
+            self.assertEqual(summary["counts"].get("normalized_source_duplicate"), 1)
+            self.assertEqual(summary["counts"].get("already_published"), 1)
+            self.assertEqual(summary["counts"].get("missing_source"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/operator/scripts/backlog/tests/test_backlog_dry_run.py
+++ b/operator/scripts/backlog/tests/test_backlog_dry_run.py
@@ -7,6 +7,48 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 from build_backlog_dry_run import build  # noqa: E402
+from normalize import normalize_repo_url, is_malformed_url  # noqa: E402
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_strip_query_fragment_slash_git(self):
+        self.assertEqual(
+            normalize_repo_url("https://github.com/Owner/Repo.git?utm=1#frag"),
+            "https://github.com/owner/repo",
+        )
+        self.assertEqual(
+            normalize_repo_url("https://github.com/owner/repo/"),
+            "https://github.com/owner/repo",
+        )
+
+    def test_monorepo_subpath_collapses_to_owner_repo(self):
+        self.assertEqual(
+            normalize_repo_url("https://github.com/owner/repo/tree/main/skills/foo"),
+            "https://github.com/owner/repo",
+        )
+        self.assertEqual(
+            normalize_repo_url("https://github.com/owner/repo/blob/main/README.md"),
+            "https://github.com/owner/repo",
+        )
+
+    def test_distinct_repos_not_merged(self):
+        a = normalize_repo_url("https://github.com/owner/repo-a")
+        b = normalize_repo_url("https://github.com/owner/repo-b")
+        self.assertNotEqual(a, b)
+
+    def test_ssh_and_shorthand(self):
+        self.assertEqual(
+            normalize_repo_url("git@github.com:Owner/Repo.git"),
+            "https://github.com/owner/repo",
+        )
+        self.assertEqual(
+            normalize_repo_url("Owner/Repo"),
+            "https://github.com/owner/repo",
+        )
+
+    def test_malformed(self):
+        self.assertTrue(is_malformed_url("https://github.com/onlyowner"))
+        self.assertIsNone(normalize_repo_url("not a url"))
 
 
 class BacklogDryRunTests(unittest.TestCase):
@@ -17,6 +59,7 @@ class BacklogDryRunTests(unittest.TestCase):
                 {"number": 2, "title": "[submission] a dup", "body": "https://github.com/o/a", "createdAt": "2026-01-02T00:00:00Z"},
                 {"number": 3, "title": "[submission] published", "body": "https://github.com/o/pub", "createdAt": "2026-01-01T00:00:00Z"},
                 {"number": 4, "title": "[submission] none", "body": "no url", "createdAt": "2026-01-01T00:00:00Z"},
+                {"number": 5, "title": "[submission] bad", "body": "https://github.com/onlyowner", "createdAt": "2026-01-01T00:00:00Z"},
             ]
         }
         catalog = {"skills": [{"repo_url": "https://github.com/o/pub"}]}
@@ -26,11 +69,53 @@ class BacklogDryRunTests(unittest.TestCase):
             (td / "cat.json").write_text(json.dumps(catalog))
             out = td / "out"
             summary = build(td / "issues.json", td / "cat.json", out)
-            self.assertEqual(summary["total"], 4)
+            self.assertEqual(summary["total"], 5)
             self.assertEqual(summary["counts"].get("canonical_actionable"), 1)
             self.assertEqual(summary["counts"].get("normalized_source_duplicate"), 1)
             self.assertEqual(summary["counts"].get("already_published"), 1)
             self.assertEqual(summary["counts"].get("missing_source"), 1)
+            self.assertEqual(summary["counts"].get("invalid_source"), 1)
+            exec_m = json.loads((out / "backlog-execution-manifest.json").read_text())
+            self.assertIn("issue_numbers_by_disposition", exec_m)
+            self.assertEqual(exec_m["issue_numbers_by_disposition"]["canonical_actionable"], [1])
+            rb = json.loads((out / "backlog-rollback-manifest.json").read_text())
+            self.assertEqual(rb["issue_numbers_touched"], [])
+
+    def test_idempotent_except_timestamp(self):
+        issues = {
+            "issues": [
+                {"number": 1, "title": "a", "body": "https://github.com/o/a", "createdAt": "2026-01-01T00:00:00Z"},
+            ]
+        }
+        catalog = {"skills": []}
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            (td / "issues.json").write_text(json.dumps(issues))
+            (td / "cat.json").write_text(json.dumps(catalog))
+            out1, out2 = td / "o1", td / "o2"
+            build(td / "issues.json", td / "cat.json", out1)
+            build(td / "issues.json", td / "cat.json", out2)
+
+            def strip(obj):
+                if isinstance(obj, dict):
+                    return {k: strip(v) for k, v in obj.items() if k != "generated_at"}
+                if isinstance(obj, list):
+                    return [strip(x) for x in obj]
+                return obj
+
+            for name in (
+                "backlog-cleanup-summary.json",
+                "backlog-cleanup-manifest.json",
+                "backlog-execution-manifest.json",
+                "backlog-rollback-manifest.json",
+            ):
+                a = json.loads((out1 / name).read_text())
+                b = json.loads((out2 / name).read_text())
+                self.assertEqual(strip(a), strip(b), name)
+            self.assertEqual(
+                (out1 / "backlog-cleanup-summary.csv").read_bytes(),
+                (out2 / "backlog-cleanup-summary.csv").read_bytes(),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Draft-only. Moves deterministic backlog dry-run tooling out of the website repo. No GitHub issue mutations. Local out/ gitignored. Unit test included.